### PR TITLE
Mcooblal/trident template

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -353,8 +353,46 @@ void DevUI_Error_Handler(char *msg, HAL_StatusTypeDef ErrorCode, uint8_t err_par
 #define FAULT9				11
 
 
-// Thresholds for FAULTS
+// Falling Edge Thresholds for FAULTS
 #define VSYS_FLT			3.5
+#define V1_FLT				0.3
+#define	V2_FLT				0.5
+#define	V3_FLT				0.9
+
+// Input GPIO Fault Level Thresholds.
+#define SOC_IN0_FLT			1
+#define SOC_IN1_FLT			0
+#define SOC_IN2_FLT			1
+#define SOC_IN3_FLT			0
+#define SOC_IN4_FLT			1
+#define SOC_IN5_FLT			0
+#define SOC_IN6_FLT			1
+#define SOC_IN7_FLT			0
+#define SOC_IN8_FLT			1
+#define SOC_IN9_FLT			0
+#define SOC_IN10_FLT		1
+#define SOC_IN11_FLT		0
+
+// Platform voltage to ADC channel mapping defines
+#define VSYS				0
+#define	V1					1
+#define V2					2
+#define V3					3
+
+// Platform GPIO Input to STM GPIO mapping
+#define SOC_IN0				0
+#define	SOC_IN1				1
+#define	SOC_IN2				2
+#define	SOC_IN3				3
+#define	SOC_IN4				4
+#define	SOC_IN5				5
+#define	SOC_IN6				6
+#define	SOC_IN7				7
+#define	SOC_IN8				8
+#define	SOC_IN9				9
+#define	SOC_IN10			10
+#define	SOC_IN11			11
+
 
 
 //spare SPI definitions
@@ -456,18 +494,18 @@ struct socI2cVoltageMux{
 static struct socI2cVoltageMux socI2cVoltageMux = {0x4C << 1, 0x14 , 0x15, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F ,0x10, 3};
 
 struct inputGPIOs{
-	int input0;
-	int input1;
-	int input2;
-	int input3;
-	int input4;
-	int input5;
-	int input6;
-	int input7;
-	int input8;
-	int input9;
-	int input10;
-	int input11;
+	uint8_t input0;
+	uint8_t input1;
+	uint8_t input2;
+	uint8_t input3;
+	uint8_t input4;
+	uint8_t input5;
+	uint8_t input6;
+	uint8_t input7;
+	uint8_t input8;
+	uint8_t input9;
+	uint8_t input10;
+	uint8_t input11;
 };
 static struct inputGPIOs inputGPIOs = {0,1,2,3,4,5,6,7,8,9,10,11};
 

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -353,13 +353,29 @@ void DevUI_Error_Handler(char *msg, HAL_StatusTypeDef ErrorCode, uint8_t err_par
 #define FAULT9				11
 
 
-// Falling Edge Thresholds for FAULTS
+// Falling Edge Thresholds for FAULTS.  Add more #defines to add additional fault thresholds for more ADC channels.
+// PLATFORM TEMPLATE: Rename these defines names to voltage rails names that match your platform.  Leave the "_FLT" suffic.
+// PLATFORM TEMPLATE: Choose appropriate falling edge thresholds for your platform.
 #define VSYS_FLT			3.5
 #define V1_FLT				0.3
 #define	V2_FLT				0.5
 #define	V3_FLT				0.9
+#define	V4_FLT				1.8
+#define	V5_FLT				1.8
+#define	V6_FLT				1.8
+#define	V7_FLT				1.8
+#define	V8_FLT				1.8
+#define	V9_FLT				1.8
+#define	V10_FLT				1.8
+#define	V11_FLT				1.8
+#define	V12_FLT				1.8
+#define	V13_FLT				1.8
+#define	V14_FLT				1.8
+#define	V15_FLT				1.8
 
 // Input GPIO Fault Level Thresholds.
+// PLATFORM TEMPLATE: Rename these defines names to logic I/O names that match your platform.  Leave the "_FLT" suffix.
+// PLATFORM TEMPLATE: Choose appropriate HI/LO fault level for each I/O for your platform.
 #define SOC_IN0_FLT			1
 #define SOC_IN1_FLT			0
 #define SOC_IN2_FLT			1
@@ -373,13 +389,28 @@ void DevUI_Error_Handler(char *msg, HAL_StatusTypeDef ErrorCode, uint8_t err_par
 #define SOC_IN10_FLT		1
 #define SOC_IN11_FLT		0
 
-// Platform voltage to ADC channel mapping defines
+// Platform voltage to ADC channel mapping defines.
+// There are currently a max of 16 ADC channels on DevUI.
+// PLATFORM TEMPLATE: Rename these defines names to voltage rails names that match your platform.
 #define VSYS				0
 #define	V1					1
 #define V2					2
 #define V3					3
+#define V4					4
+#define V5					5
+#define V6					6
+#define V7					7
+#define V8					8
+#define V9					9
+#define V10					10
+#define V11					11
+#define V12					12
+#define V13					13
+#define V14					14
+#define V15					15
 
-// Platform GPIO Input to STM GPIO mapping
+// Platform GPIO Input to STM GPIO mapping.  There are a max of 12 GPIO inputs on the DevUI.
+// PLATFORM TEMPLATE: Rename these defines names to logic I/O names that match your platform.
 #define SOC_IN0				0
 #define	SOC_IN1				1
 #define	SOC_IN2				2

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -2551,12 +2551,14 @@ void startErrorLEDs(void *argument)
 	float * presentADCValues;
 
 	// An array of voltage rails that are monitored for faults.  Each element maps to the apporpriate ADC channel for monitoring
+	// PLATFORM TEMPLATE: edit this array to include the voltages that you would like to monitor for faults.  The names are defined in main.h
 	uint8_t monitor_rails[] = {VSYS, V1, V2, V3};
 
-	// An array of falling edge fault thresholds for the voltage rails that are monitored for faults.
+	// An array of falling edge fault thresholds for the voltage rails that are monitored for faults.  Size of the array and index for each fault should match the voltage name in monitor_rails[].
 	double monitor_fault_thresholds[] = {VSYS_FLT, V1_FLT, V2_FLT, V3_FLT};
 
 	// An array of platform gpio inputs that are monitored for faults.  Each element maps to the appropriate STM GPIO input for monitoring
+	// PLATFORM TEMPLATE: edit this array to include the voltages that you would like to monitor for faults.  The names are defined in main.h
 	uint8_t monitor_gpio[] = {SOC_IN0, SOC_IN3, SOC_IN8, SOC_IN11};
 
 	// An array of logic fault thresholds for the GPIO input rails that are monitored for faults.  The fault thresholds should match the mapping used in monitor_gpio[].

--- a/Core/Src/menu.c
+++ b/Core/Src/menu.c
@@ -568,7 +568,7 @@ void drawStatusMenu(int indicator){
 		if(i2cCheck == HAL_OK){
 			LCD_PutStr(i, j, "Present", fnt7x10);
 			// Clear the HAL fault LED.
-			errorLED.fault9 = false;
+			//errorLED.fault9 = false;
 		}
 		else{
 			LCD_PutStr(i, j, "Undetected", fnt7x10);


### PR DESCRIPTION
- Added general macro, and code template for voltage & I/O fault monitoring to support different platforms.  
- The templates can be slightly tweaked to support different platforms without needing to rewrite a large amount of code.  
- I marked instructions / areas where these changes need to occur with the comment marker "PLATFORM TEMPLATE:"